### PR TITLE
Add the `watchosArm32` target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
     iosArm64()
 
     watchosX64()
+    watchosArm32()
     watchosArm64()
 
     tvosX64()
@@ -92,6 +93,9 @@ kotlin {
             dependsOn(darwinMain)
         }
 
+        val watchosArm32Main by getting {
+            dependsOn(darwinMain)
+        }
         val watchosArm64Main by getting {
             dependsOn(darwinMain)
         }


### PR DESCRIPTION
Adding the `watchosArm32` target, required for the Apple Watch Series 3 [[ref](https://kotlinlang.org/docs/mobile/supported-platforms.html)], for which, the latest watchOS version (watchOS 7) is still supported [[ref](https://www.apple.com/watchos/watchos-7/)].