### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/analyze-detekt.yml
+++ b/.github/workflows/analyze-detekt.yml
@@ -12,6 +12,7 @@ jobs:
   scan:
     name: Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
     - name: Setup detekt

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -19,6 +19,7 @@ jobs:
             targets: native
           - os: windows-latest
             targets: native
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -49,6 +50,7 @@ jobs:
             targets: native
             publishRootTarget: false
       fail-fast: false
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -76,6 +78,7 @@ jobs:
   release:
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259