### PR TITLE
ci: Remove deprecated set-output usage

### DIFF
--- a/.github/workflows/analyze-detekt.yml
+++ b/.github/workflows/analyze-detekt.yml
@@ -24,7 +24,7 @@ jobs:
           --silent \
           --location \
           --output $JARFILE
-        echo "::set-output name=jarfile::$JARFILE"
+        echo "jarfile=$JARFILE" >> $GITHUB_OUTPUT
     - name: Run detekt
       continue-on-error: true
       run: |

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -62,7 +62,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - id: get_tag_version
-        run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/v}"
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         shell: bash
       - run: sudo apt-get install -y libunistring-dev libc6-dev-i386
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Overview

`set-output` is being deprecated and will cause failures June 2023. Updated to the recommended approach.

## Reference

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/Doist/infrastructure-backlog/issues/481

